### PR TITLE
Replace text at a given index in a node

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -125,6 +125,17 @@ describe("Aracari", () => {
       .remap();
     expect(aracari.getText()).toBe("Foo bar or foo bar");
   });
+  test("replaceText when passed an option of replacementIndex should replace the text that matches that index", () => {
+    const element = document.createElement("div");
+    element.innerHTML = "<p>foo bar or foo bar</p>";
+    aracari = new Aracari(element);
+    aracari
+      .replaceText("foo bar", [document.createTextNode("baz qux")], {
+        replacementIndex: 1,
+      })
+      .remap();
+    expect(aracari.getText()).toBe("foo bar or baz qux");
+  });
   test("getAddressesForText should return an array of addresses that match the given text passed in", () => {
     const addresses = aracari.getAddressesForText("toucan");
     expect(addresses).toEqual(["0.21.0", "0.23.0"]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ interface Config {
 interface ReplaceOptions {
   at?: string;
   perserveWord?: boolean;
+  replacementIndex?: number;
 }
 
 type Mapping = string[][];
@@ -80,7 +81,7 @@ export class Aracari<T extends HTMLElement = HTMLElement> {
     options: ReplaceOptions = {}
   ) {
     let node;
-    const { at, perserveWord } = options;
+    const { at, perserveWord, replacementIndex = 0 } = options;
     if (at) {
       node = this.getNodeByAddress(at);
     } else {
@@ -91,11 +92,13 @@ export class Aracari<T extends HTMLElement = HTMLElement> {
       throw new Error("Text not found in node");
     }
     const delimiter = perserveWord ? "\\b" : "";
-    const [preText, ...postText] = node.textContent.split(
+    const contents = node.textContent.split(
       new RegExp(`${delimiter}${text}${delimiter}`, "g")
     );
+    const preText = contents.slice(0, replacementIndex + 1);
+    const postText = contents.slice(replacementIndex + 1);
     const replacementNodes = [
-      this.maybeCreateTextNode(preText),
+      this.maybeCreateTextNode(preText.join(text)),
       ...(Array.isArray(nodes) ? nodes : [nodes]),
       this.maybeCreateTextNode(postText.join(text)),
     ].filter((x) => x);


### PR DESCRIPTION
## Description

This allows for the percise replacement of text, if duplicated, in a given text node. Before Ararcari would just replace the first instance. This now allows use to pick the percise index of that text.

For instance.

```typescript
// <p>foo bar o foo bar</p>

aracari.replaceText('foo bar', document.createTextNode('baz qux'));
```

Could only result in `baz qux o foo bar`. Now it is possible to select the second instance of it by passing the `replacementIndex` of 1.
