### PR TITLE
Fix appending nodes

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -140,4 +140,44 @@ describe("Aracari", () => {
     const addresses = aracari.getAddressesForText("toucan");
     expect(addresses).toEqual(["0.21.0", "0.23.0"]);
   });
+  test("replaceText should not append nodes if no matches are found", () => {
+    const element = document.createElement("div");
+    const replacementOptions = { perserveWord: true };
+    // Taken from https://en.wikipedia.org/wiki/French_Polynesia#Culture
+    element.innerHTML = `<p><a href="/wiki/French_language" title="French language">French</a> is the only official language of French Polynesia.<sup id="cite_ref-35" class="reference"><a href="#cite_note-35">[31]</a></sup> An <a href="/wiki/Organic_law" title="Organic law">organic law</a> of 12 April 1996 states that "French is the official language, Tahitian and other Polynesian languages can be used." At the 2017 census, among the population whose age was 15 and older</p>`;
+    aracari = new Aracari(element);
+    // Replace the two that are in the sentence
+    aracari
+      .replaceText(
+        "language",
+        [document.createTextNode("foo")],
+        replacementOptions
+      )
+      .remap()
+      .replaceText(
+        "language",
+        [document.createTextNode("bar")],
+        replacementOptions
+      )
+      .remap();
+
+    expect(() => {
+      aracari
+        .replaceText(
+          "language",
+          [document.createTextNode("baz")],
+          replacementOptions
+        )
+        .remap()
+        .replaceText(
+          "language",
+          [document.createTextNode("qux")],
+          replacementOptions
+        )
+        .remap();
+    }).toThrowError(/not found/);
+    expect(aracari.getText()).toBe(
+      `French is the only official foo of French Polynesia.[31] An organic law of 12 April 1996 states that "French is the official bar, Tahitian and other Polynesian languages can be used." At the 2017 census, among the population whose age was 15 and older`
+    );
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,19 +82,19 @@ export class Aracari<T extends HTMLElement = HTMLElement> {
   ) {
     let node;
     const { at, perserveWord, replacementIndex = 0 } = options;
+
     if (at) {
       node = this.getNodeByAddress(at);
     } else {
       node = this.getTextNode(text);
     }
+    const delimiter = perserveWord ? "\\b" : "";
+    const pattern = new RegExp(`${delimiter}${text}${delimiter}`, "g");
     // Handling text around replacement text
-    if (!node.textContent.match(text)) {
+    if (!node.textContent.match(pattern)) {
       throw new Error("Text not found in node");
     }
-    const delimiter = perserveWord ? "\\b" : "";
-    const contents = node.textContent.split(
-      new RegExp(`${delimiter}${text}${delimiter}`, "g")
-    );
+    const contents = node.textContent.split(pattern);
     const preText = contents.slice(0, replacementIndex + 1);
     const postText = contents.slice(replacementIndex + 1);
     const replacementNodes = [


### PR DESCRIPTION
## Description

This happens when there are multiple version of a word on a sententence and you attempt to append multiple of the same word to the sentence. In the test case the is the word we want to replace "language" and then a version of it "languages" that would not trigger the text not found error. Now the proper error is thrown and multiple instances of the word are not appended.
