### PR TITLE
Escape regular expressions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import { escapeRegExp } from "./utils";
+
 interface Config {
   textNodeType: number;
   createTextNode?: (text: string) => Node;
@@ -89,7 +91,10 @@ export class Aracari<T extends HTMLElement = HTMLElement> {
       node = this.getTextNode(text);
     }
     const delimiter = perserveWord ? "\\b" : "";
-    const pattern = new RegExp(`${delimiter}${text}${delimiter}`, "g");
+    const pattern = new RegExp(
+      `${delimiter}${escapeRegExp(text)}${delimiter}`,
+      "g"
+    );
     // Handling text around replacement text
     if (!node.textContent.match(pattern)) {
       throw new Error("Text not found in node");
@@ -103,7 +108,7 @@ export class Aracari<T extends HTMLElement = HTMLElement> {
       this.maybeCreateTextNode(postText.join(text)),
     ].filter((x) => x);
 
-    // Replace existing text node with new nodelist.
+    // Replace existing text node with new node-list.
     node.replaceWith(...replacementNodes);
     return this;
   }
@@ -140,7 +145,7 @@ export class Aracari<T extends HTMLElement = HTMLElement> {
   ): string[][] {
     const delimiter = perserveWord ? "\\b" : "";
     const pattern = new RegExp(
-      `${delimiter}${text}${delimiter}`,
+      `${delimiter}${escapeRegExp(text)}${delimiter}`,
       `${caseSensitive ? "i" : ""}g`
     );
     return this.mapping.filter(([text]) => !!text.match(pattern));

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 import { escapeRegExp } from "./utils";
 
+export { escapeRegExp } from "./utils";
+
 interface Config {
   textNodeType: number;
   createTextNode?: (text: string) => Node;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,16 @@
+const reRegExpChar = /[\\^$.*+?()[\]{}|]/g;
+const reHasRegExpChar = RegExp(reRegExpChar.source);
+
+/**
+ * Escapes the `RegExp` special characters "^", "$", "\", ".", "*", "+",
+ * "?", "(", ")", "[", "]", "{", "}", and "|" in `string`.
+ *
+ * @param {string} text The string to escape.
+ * @returns {string} Returns the escaped string.
+ */
+
+export const escapeRegExp = (text: string) => {
+  return text && reHasRegExpChar.test(text)
+    ? text.replace(reRegExpChar, "\\$&")
+    : text || "";
+};


### PR DESCRIPTION
## Description

This fixes some issues with trying to replace and parse text. The regular expressions would fail if we passed in text like "This (text)", and this allows that to be properly used.
