### PR TITLE
Use Non-Word Bound Matching for Non-Latin Scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aracari",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "This is a small utility to pull text from html and also replace text in html.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -103,24 +103,24 @@ describe("Aracari", () => {
     aracari.replaceText("all", [document.createTextNode("todo")]).remap();
     expect(aracari.getText()).toBe("todo the foo people are all bar");
   });
-  test("replaceText when passed an option of perserveWord should not replace fragments", () => {
+  test("replaceText when passed an option of preserveWord should not replace fragments", () => {
     const element = document.createElement("div");
     element.innerHTML = "<p>Done is the one thing.</p>";
     aracari = new Aracari(element);
     aracari
       .replaceText("one", [document.createTextNode("uno")], {
-        perserveWord: true,
+        preserveWord: true,
       })
       .remap();
     expect(aracari.getText()).toBe("Done is the uno thing.");
   });
-  test("replaceText when passed an option of perserveWord and a sentence should still work", () => {
+  test("replaceText when passed an option of preserveWord and a sentence should still work", () => {
     const element = document.createElement("div");
     element.innerHTML = "<p>Foo bar or oo bar</p>";
     aracari = new Aracari(element);
     aracari
       .replaceText("oo bar", [document.createTextNode("foo bar")], {
-        perserveWord: true,
+        preserveWord: true,
       })
       .remap();
     expect(aracari.getText()).toBe("Foo bar or foo bar");
@@ -142,7 +142,7 @@ describe("Aracari", () => {
   });
   test("replaceText should not append nodes if no matches are found", () => {
     const element = document.createElement("div");
-    const replacementOptions = { perserveWord: true };
+    const replacementOptions = { preserveWord: true };
     // Taken from https://en.wikipedia.org/wiki/French_Polynesia#Culture
     element.innerHTML = `<p><a href="/wiki/French_language" title="French language">French</a> is the only official language of French Polynesia.<sup id="cite_ref-35" class="reference"><a href="#cite_note-35">[31]</a></sup> An <a href="/wiki/Organic_law" title="Organic law">organic law</a> of 12 April 1996 states that "French is the official language, Tahitian and other Polynesian languages can be used." At the 2017 census, among the population whose age was 15 and older</p>`;
     aracari = new Aracari(element);

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ interface ReplaceOptions {
   at?: string;
   preserveWord?: boolean;
   replacementIndex?: number;
-  nonWordBoundMatch?: boolean;
+  shouldUseNonLatinMatch?: boolean;
 }
 
 type Mapping = string[][];
@@ -80,19 +80,19 @@ export class Aracari<T extends HTMLElement = HTMLElement> {
     return this.getNodeByAddress(address);
   }
 
-  private nonWordBoundMatchReplacement = (
-    { node,
-      text,
-      nodes,
-      replacementIndex
-    }: {
-      node: any;
-      text: string,
-      nodes: T | Node | (T | Node)[];
-      replacementIndex: number;
-    }) => {
+  private nonLatinMatchAndReplacement = ({
+    node,
+    text,
+    nodes,
+    replacementIndex
+  }: {
+    node: any;
+    text: string,
+    nodes: T | Node | (T | Node)[];
+    replacementIndex: number;
+  }) => {
     // Using this pattern because look-around regex not supported in some browsers
-    // \b Word bound works with latin based characters and does not work with other characters
+    // (\b) word bound does not work with non-latin scripts
     const pattern = new RegExp(
       `(?:^|\\s)${escapeRegExp(text)}(?:$|\\s|[.!?,"'])`,
       "g"
@@ -128,7 +128,7 @@ export class Aracari<T extends HTMLElement = HTMLElement> {
     options: ReplaceOptions = {}
   ) {
     let node;
-    const { at, preserveWord, replacementIndex = 0, nonWordBoundMatch = false } = options;;
+    const { at, preserveWord, replacementIndex = 0, shouldUseNonLatinMatch = false } = options;;
 
     if (at) {
       node = this.getNodeByAddress(at);
@@ -136,9 +136,9 @@ export class Aracari<T extends HTMLElement = HTMLElement> {
       node = this.getTextNode(text);
     }
 
-    // Use non word bound '\b' matching and replacement
-    if (nonWordBoundMatch) {
-      return this.nonWordBoundMatchReplacement({ node, text, nodes, replacementIndex });
+    // Use non word bound ('\b') matching and replacement
+    if (shouldUseNonLatinMatch) {
+      return this.nonLatinMatchAndReplacement({ node, text, nodes, replacementIndex });
     }
 
     const delimiter = preserveWord ? "\\b" : "";

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,69 +80,84 @@ export class Aracari<T extends HTMLElement = HTMLElement> {
     return this.getNodeByAddress(address);
   }
 
-  public replaceText(
-    text: string,
-    nodes: T | Node | (T | Node)[],
-    options: ReplaceOptions = {}
-  ) {
-    let node;
-    const { at, preserveWord, replacementIndex = 0, nonWordBoundMatch = true } = options;
-    console.log('options :>> ', options);
-
-    if (at) {
-      node = this.getNodeByAddress(at);
-    } else {
-      node = this.getTextNode(text);
-    }
-    const delimiter = preserveWord ? "\\b" : "";
-    const pattern = nonWordBoundMatch ?
-      new RegExp(
-        `(?:^|\\s)${escapeRegExp(text)}(?:$|\\s|[.!?,"'])`,
-        "g"
-      ) :
-      new RegExp(
-        `${delimiter}${escapeRegExp(text)}${delimiter}`,
-        "g"
-      );
-
-    console.log('pattern :>> ', pattern);
-    console.log('node.textContent.match(pattern) :>> ', node.textContent.match(pattern));
-    // Handling text around replacement text
+  private nonWordBoundMatchReplacement = (
+    { node,
+      text,
+      nodes,
+      replacementIndex
+    }: {
+      node: any;
+      text: string,
+      nodes: T | Node | (T | Node)[];
+      replacementIndex: number;
+    }) => {
+    // Using this pattern because look-around regex not supported in some browsers
+    // \b Word bound works with latin based characters and does not work with other characters
+    const pattern = new RegExp(
+      `(?:^|\\s)${escapeRegExp(text)}(?:$|\\s|[.!?,"'])`,
+      "g"
+    );
     if (!node.textContent.match(pattern)) {
       throw new Error("Text not found in node");
     }
-
     const matchingPhrase = node.textContent.match(pattern)[0];
-
+    // Preceding character matching and delimiting
     const isFirstDelimitingCharacter = matchingPhrase.charAt(0).match(new RegExp(`\\s|^|[ ]`))[0] !== "";
-    console.log(`character at 0: !${matchingPhrase.charAt(0)}!`);
-    console.log('matchingPhrase.charAt(0) :>> ', '!' + matchingPhrase.charAt(0).match(new RegExp(`\\s|^|[ ]`)));
     const precedingCharacter = isFirstDelimitingCharacter ? matchingPhrase.charAt(0) : "";
-    console.log('isFirstDelimitingCharacter :>> ', isFirstDelimitingCharacter);
-
+    // Following character matching and delimiting
     const isLastDelimitingCharacter = matchingPhrase.charAt(matchingPhrase - 1).match(new RegExp(`($|\\s|[.!?,"'])`))[0] !== "";
     const lastCharacter = isLastDelimitingCharacter ? matchingPhrase.charAt(matchingPhrase - 1) : "";
-    console.log('isLastDelimitingCharacter :>> ', isLastDelimitingCharacter);
-
-    console.log('matchingPhrase :>> ', matchingPhrase);
-    console.log('precedingCharacter :>> ', precedingCharacter);
-    console.log('lastCharacter :>> ', lastCharacter);
-
     const contents = node.textContent.split(pattern);
-    console.log('contents :>> ', contents);
-
     const preText = contents.slice(0, replacementIndex + 1);
-    console.log('preText :>> ', preText);
-
     const postText = contents.slice(replacementIndex + 1);
-    console.log('postText :>> ', postText);
 
     const replacementNodes = [
       this.maybeCreateTextNode(preText.join(text) + precedingCharacter),
       ...(Array.isArray(nodes) ? nodes : [nodes]),
       this.maybeCreateTextNode(lastCharacter + postText.join(text)),
     ].filter((x) => x);
-    console.log('replacementNodes :>> ', replacementNodes);
+
+    // Replace existing text node with new node-list.
+    node.replaceWith(...replacementNodes);
+    return this;
+  }
+
+  public replaceText(
+    text: string,
+    nodes: T | Node | (T | Node)[],
+    options: ReplaceOptions = {}
+  ) {
+    let node;
+    const { at, preserveWord, replacementIndex = 0, nonWordBoundMatch = false } = options;;
+
+    if (at) {
+      node = this.getNodeByAddress(at);
+    } else {
+      node = this.getTextNode(text);
+    }
+
+    // Use non word bound '\b' matching and replacement
+    if (nonWordBoundMatch) {
+      return this.nonWordBoundMatchReplacement({ node, text, nodes, replacementIndex });
+    }
+
+    const delimiter = preserveWord ? "\\b" : "";
+    const pattern = new RegExp(
+      `${delimiter}${escapeRegExp(text)}${delimiter}`,
+      "g"
+    );
+    // Handling text around replacement text
+    if (!node.textContent.match(pattern)) {
+      throw new Error("Text not found in node");
+    }
+    const contents = node.textContent.split(pattern);
+    const preText = contents.slice(0, replacementIndex + 1);
+    const postText = contents.slice(replacementIndex + 1);
+    const replacementNodes = [
+      this.maybeCreateTextNode(preText.join(text)),
+      ...(Array.isArray(nodes) ? nodes : [nodes]),
+      this.maybeCreateTextNode(postText.join(text)),
+    ].filter((x) => x);
 
     // Replace existing text node with new node-list.
     node.replaceWith(...replacementNodes);

--- a/src/index.ts
+++ b/src/index.ts
@@ -222,7 +222,7 @@ export class Aracari<T extends HTMLElement = HTMLElement> {
       if (node.nodeType === textNodeType) {
         return [[node.textContent, [...path, i].join(".")]];
       }
-      if (typeof node === "object" && node ?.childNodes ?.length) {
+      if (typeof node === "object" && node?.childNodes?.length) {
         return this.getTextNodeMapping(node as T, [...path, i]);
       }
       return [];


### PR DESCRIPTION
Introduces a new regex pattern for matching and replacement. Word bound matching does not work for non-Latin script and because "look-around" logic is not supported in some browsers we have to use character matching and cleanup. We maintain the old word-bound matching logic for Latin-based scripts.